### PR TITLE
modify to always release

### DIFF
--- a/cr.sh
+++ b/cr.sh
@@ -252,15 +252,16 @@ filter_charts() {
 }
 
 lookup_changed_charts() {
-    local commit="$1"
+    #local commit="$1"
 
-    local changed_files
-    changed_files=$(git diff --find-renames --name-only "$commit" -- "$charts_dir")
+    #local changed_files
+    #changed_files=$(git diff --find-renames --name-only "$commit" -- "$charts_dir")
 
-    local depth=$(( $(tr "/" "\n" <<< "$charts_dir" | sed '/^\(\.\)*$/d' | wc -l) + 1 ))
-    local fields="1-${depth}"
+    #local depth=$(( $(tr "/" "\n" <<< "$charts_dir" | sed '/^\(\.\)*$/d' | wc -l) + 1 ))
+    #local fields="1-${depth}"
 
-    cut -d '/' -f "$fields" <<< "$changed_files" | uniq | filter_charts
+    #cut -d '/' -f "$fields" <<< "$changed_files" | uniq | filter_charts
+    echo ${charts_dir}/* | filter_charts
 }
 
 package_chart() {


### PR DESCRIPTION
`lookup_changed_charts` will return `operator/charts/netchecks` to `changed_charts` which ensures it won't be skipped for a release